### PR TITLE
Revert "Improve Makefile and fix systemd paths"

### DIFF
--- a/systemd/Makefile
+++ b/systemd/Makefile
@@ -3,25 +3,18 @@
 PREFIX = /usr/local
 SYSTEMD_DIR = /usr/lib/systemd
 SYSTEMD_UNIT_DIR = $(SYSTEMD_DIR)/system
-SYSTEMD_USER_DIR = $(SYSTEMD_DIR)/user
 
 install:
-	sed "s|<PREFIX>|$(PREFIX)|; s|<USER>|nobody|" popub-local@.service.in > popub-local@.service
-	sed "s|<PREFIX>|$(PREFIX)|; s|<USER>|nobody|" popub-relay@.service.in > popub-relay@.service
+	sed "s|@PREFIX@|$(PREFIX)|" popub-local@.service.in > popub-local@.service
+	sed "s|@PREFIX@|$(PREFIX)|" popub-relay@.service.in > popub-relay@.service
 	install -Dm0644 popub-local@.service "$(DESTDIR)$(SYSTEMD_UNIT_DIR)/popub-local@.service"
 	install -Dm0644 popub-relay@.service "$(DESTDIR)$(SYSTEMD_UNIT_DIR)/popub-relay@.service"
 
-	sed "s|<PREFIX>|$(PREFIX)|; s|<USER>|%u|; /CAP_NET/d" popub-local@.service.in > popub-local@.service
-	sed "s|<PREFIX>|$(PREFIX)|; s|<USER>|%u|; /CAP_NET/d" popub-relay@.service.in > popub-relay@.service
-	install -Dm0644 popub-local@.service "$(DESTDIR)$(SYSTEMD_USER_DIR)/popub-local@.service"
-	install -Dm0644 popub-relay@.service "$(DESTDIR)$(SYSTEMD_USER_DIR)/popub-relay@.service"
-
-	install -Dm0644 example-local.conf "$(DESTDIR)/etc/popub/local.d/example"
-	install -Dm0644 example-relay.conf "$(DESTDIR)/etc/popub/relay.d/example"
+	install -Dm0644 example-local.conf "$(DESTDIR)/etc/popub/local/example.conf"
+	install -Dm0644 example-relay.conf "$(DESTDIR)/etc/popub/relay/example.conf"
 	systemctl daemon-reload || true
 
 uninstall:
 	rm -f "$(DESTDIR)$(SYSTEMD_UNIT_DIR)"/popub-{local,relay}@.service
-	rm -f "$(DESTDIR)$(SYSTEMD_USER_DIR)"/popub-{local,relay}@.service
 	rm -rf "$(DESTDIR)/etc/popub/"
 	systemctl daemon-reload || true

--- a/systemd/popub-local@.service.in
+++ b/systemd/popub-local@.service.in
@@ -5,13 +5,12 @@ After=network-online.target
 [Service]
 Type=simple
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-EnvironmentFile=/etc/popub/local.d/%i
-EnvironmentFile=%h/.config/popub/%i
-ExecStart=<PREFIX>/bin/popub-local "$LOCAL_ADDR" "$RELAY_ADDR" "$AUTH_KEY"
+EnvironmentFile=/etc/popub/local/%i.conf
+ExecStart=@PREFIX@/bin/popub-local "$LOCAL_ADDR" "$RELAY_ADDR" "$AUTH_KEY"
 LimitNOFILE=1048576
 Restart=always
 RestartSec=3
-User=<USER>
+User=nobody
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/popub-relay@.service.in
+++ b/systemd/popub-relay@.service.in
@@ -5,13 +5,12 @@ After=network-online.target
 [Service]
 Type=simple
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-EnvironmentFile=/etc/popub/relay.d/%i
-EnvironmentFile=%h/.config/popub/%i
-ExecStart=<PREFIX>/bin/popub-relay "$RELAY_ADDR" "$PUBLIC_ADDR" "$AUTH_KEY"
+EnvironmentFile=/etc/popub/relay/%i.conf
+ExecStart=@PREFIX@/bin/popub-relay "$RELAY_ADDR" "$PUBLIC_ADDR" "$AUTH_KEY"
 LimitNOFILE=1048576
 Restart=always
 RestartSec=3
-User=<USER>
+User=nobody
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Reverts m13253/popub#2

## Summary:

Due to the unusability and security risks of user units, along with the inconsistency and incompatibility caused by the configuration file change. I propose to revert (some of) the changes of pull request #2, making it more secure and more useful.

## Changes

Affected features:
- user units
- file name change

Unaffected features:
- PREFIX & DESTDIR support
- system unit template

## Detailed description

### User units

By default, user units starts as your session starts and ends as your session finishes, unless you "enable-linger" your account, which will require a root authentication. Thus, you must have root access to make use of user units.

Since you already have root access, you will certainly have Popub as a system service. It will be more secure than a user service (because you can drop to `nobody`, while user services can't).

By the way, Popub requires `CAP_NET_BIND_SERVICE` to bind to lower ports. Disabling it makes Popub less useful. Enabling it for non-root user brings a security issue for a multi-user system.

In addition, both the system & user units added via #2 crashes at launch. It is submitted prior to tests, and does not work.

### File name change

Pull Request #1 changed the configuration files from `/etc/popub/local/example.conf` to `/etc/popub/local.d/example`. I consider it as inappropriate.

Usually `.d` is considered a substitution of a single `.conf`. In other words, `cat foo.d/*` equals `foo.conf`. This is the fact as `fontconfig`, `sysctl`, `Xorg` and various famous packages do.

Moreover, removing `.conf` suffix does not make any sense. There is no reason to deny its configuration file identity.

## Distro Migrating

According to the fact that Fedora has adopted Popub in its official repository, it will become a problem if the configuration file name has changed.
I suggest:
- Either keep the original configuration file names for Fedora (Shadowsocks-libev is such an example, whose configuration files are different among different distributions)
- Put an automatic migration script into the packaging script

Anyway, thanks for @1dot75cm 's contribution. I'm reverting (some of) the change, because I want to improve Popub, making it more secure and more useful.

Now open for discussion.